### PR TITLE
Go live fixes november2018

### DIFF
--- a/Tipstaff/Classes/SearchResults.cs
+++ b/Tipstaff/Classes/SearchResults.cs
@@ -142,7 +142,7 @@ namespace Tipstaff
                             name = child.fullname, 
                             partyID = child.childID,
                             tipstaffRecordID = child.tipstaffRecordID, 
-                            DateOfBirth = (DateTime)child.dateOfBirth, 
+                            DateOfBirth = child.dateOfBirth, 
                             PartyType="Child", 
                             tipstaffRecordType = "ChildAbduction", 
                             tipstaffUniqueRecordID = uniqID

--- a/Tipstaff/Models/DocumentModels.cs
+++ b/Tipstaff/Models/DocumentModels.cs
@@ -32,7 +32,7 @@ namespace Tipstaff.Models
         public byte[] binaryFile { get; set; }
         [ScaffoldColumn(false), MaxLength(256)]
         public string fileName { get; set; }
-        [ScaffoldColumn(false), MaxLength(60)]
+        [ScaffoldColumn(false), MaxLength(300)]
         public string mimeType { get; set; }
         public virtual Country country { get; set; }
         public virtual Nationality nationality { get; set; }


### PR DESCRIPTION
1) Documents' mimetype maxlength set to 300
2) search won't break if the child's date of birth is null